### PR TITLE
Fix broken targeting with stacked accelerated Tile Entities

### DIFF
--- a/common/src/main/java/org/mangorage/tiab/common/client/renderer/BlockFaceTextRenderer.java
+++ b/common/src/main/java/org/mangorage/tiab/common/client/renderer/BlockFaceTextRenderer.java
@@ -5,6 +5,7 @@ import com.mojang.math.Axis;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.LightTexture;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
@@ -40,7 +41,7 @@ public record BlockFaceTextRenderer(Font font, Vector3f vector3f) {
                 source, // MultiBufferSource
                 Font.DisplayMode.NORMAL, // DisplayMode
                 backgroundColor, // Background Color
-                pPackedLightCoords // pPackedLightsCoords
+                LightTexture.FULL_BRIGHT // pPackedLightsCoords
         );
         matrixStack.popPose();
     }
@@ -59,10 +60,10 @@ public record BlockFaceTextRenderer(Font font, Vector3f vector3f) {
             return v.set(-z, y, -x);
         }, Axis.YP.rotationDegrees(-90F)),
         TOP((v, x, y, z) -> {
-            return v.set(-x, z, -y);
+            return v.set(-x, z + 0.5F, -y + 0.5F);
         }, Axis.XP.rotationDegrees(90F)),
-        BOTTON((v, x, y, z) -> {
-            return v.set(-x, -z, y);
+        BOTTOM((v, x, y, z) -> {
+            return v.set(-x, -z + 0.5F, y - 0.5F);
         }, Axis.XP.rotationDegrees(-90F));
 
         private static final List<Face> FACES = List.of(values());

--- a/common/src/main/java/org/mangorage/tiab/common/client/renderer/TimeAcceleratorEntityRenderer.java
+++ b/common/src/main/java/org/mangorage/tiab/common/client/renderer/TimeAcceleratorEntityRenderer.java
@@ -1,6 +1,7 @@
 package org.mangorage.tiab.common.client.renderer;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
@@ -9,6 +10,12 @@ import org.mangorage.tiab.common.entities.TimeAcceleratorEntity;
 
 public final class TimeAcceleratorEntityRenderer extends EntityRenderer<TimeAcceleratorEntity> {
     private static final BlockFaceTextRenderer textRenderer = BlockFaceTextRenderer.create();
+	
+	private static final float TEXT_1PX_BELOW_MIDDLE = 0.4375F;
+	private static final float TEXT_1PX_ABOVE_MIDDLE = 0.7063F;
+	
+	private static final float PADDING_2CHAR = 0.11F;
+	private static final float PADDING_3CHAR = 0.19F;
 
     public TimeAcceleratorEntityRenderer(EntityRendererProvider.Context erp) {
         super(erp);
@@ -17,15 +24,16 @@ public final class TimeAcceleratorEntityRenderer extends EntityRenderer<TimeAcce
     @Override
     public void render(TimeAcceleratorEntity entity, float entityYaw, float partialTicks, PoseStack poseStack, MultiBufferSource bufferSource, int packedLightIn) {
         String timeRate = "x" + 2 * entity.getTimeRate();
-        float paddingLeftRight = 2 * entity.getTimeRate() < 10 ? 0.11F : 0.19F;
+        float paddingLeftRightMult = 2 * entity.getTimeRate() < 10 ? PADDING_2CHAR : PADDING_3CHAR;
 
         int remainingTimeSeconds = entity.getRemainingTime() / 20;
         String timeRemaining = remainingTimeSeconds + "s";
+        float paddingLeftRightTime = remainingTimeSeconds < 10 ? PADDING_2CHAR : PADDING_3CHAR;
 
         var rendererText = textRenderer.of(poseStack, bufferSource);
 
-        rendererText.render(BlockFaceTextRenderer.Face.valuesList(), timeRate, packedLightIn, 16777215, paddingLeftRight, 0.064F, 0.51F); // Render Time Rate
-        rendererText.render(BlockFaceTextRenderer.Face.valuesList(), timeRemaining, packedLightIn, remainingTimeSeconds > 10 ? 16777215 : 16711680, paddingLeftRight, 0.264F, 0.51F); // Render Time Remaining, goes reed when < 10 seconds, otherwise white text.
+        rendererText.render(BlockFaceTextRenderer.Face.valuesList(), timeRate, packedLightIn, ChatFormatting.WHITE.getColor(), paddingLeftRightMult, TEXT_1PX_BELOW_MIDDLE, 0.51F); // Render Time Rate
+        rendererText.render(BlockFaceTextRenderer.Face.valuesList(), timeRemaining, packedLightIn, remainingTimeSeconds > 10 ? ChatFormatting.WHITE.getColor() : ChatFormatting.RED.getColor(), paddingLeftRightTime, TEXT_1PX_ABOVE_MIDDLE, 0.51F); // Render Time Remaining, goes reed when < 10 seconds, otherwise white text.
     }
 
     @Override

--- a/common/src/main/java/org/mangorage/tiab/common/entities/TimeAcceleratorEntity.java
+++ b/common/src/main/java/org/mangorage/tiab/common/entities/TimeAcceleratorEntity.java
@@ -114,7 +114,7 @@ public class TimeAcceleratorEntity extends Entity implements ITimeAcceleratorEnt
     @Override
     public void setBlockPos(BlockPos blockPos) {
         this.pos = blockPos.immutable();
-        this.setPos(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5);
+        this.setPos(pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5);
     }
 
     @Override

--- a/fabric/src/main/java/org/mangorage/tiab/fabric/core/Registration.java
+++ b/fabric/src/main/java/org/mangorage/tiab/fabric/core/Registration.java
@@ -42,7 +42,7 @@ public final class Registration {
     public static final EntityType<TimeAcceleratorEntity> ACCELERATOR_ENTITY = register(BuiltInRegistries.ENTITY_TYPE, "accelerator", EntityType.Builder.<TimeAcceleratorEntity>of(
             (entityType, level) -> new TimeAcceleratorEntity(level),
             MobCategory.MISC
-    ).build("accelerator"));
+    ).sized​(1.0f, 1.0f).build("accelerator"));
 
     public static final CreativeModeTab TIAB_CREATIVE_TAB = register(BuiltInRegistries.CREATIVE_MODE_TAB, "tiab", CreativeModeTab.builder(CreativeModeTab.Row.TOP, 0)
             .icon(TIAB_ITEM::getDefaultInstance)

--- a/forge/src/main/java/org/mangorage/tiab/forge/core/Registration.java
+++ b/forge/src/main/java/org/mangorage/tiab/forge/core/Registration.java
@@ -47,7 +47,7 @@ public final class Registration {
             () -> EntityType.Builder.<TimeAcceleratorEntity>of(
                     (entityType, level) -> new TimeAcceleratorEntity(level),
                     MobCategory.MISC
-            ).build("accelerator"));
+            ).sized​(1.0f, 1.0f).build("accelerator"));
 
     public static final RegistryObject<CreativeModeTab> TIAB_CREATIVE_TAB = TABS.register("tiab", () -> CreativeModeTab.builder()
             .icon(() -> TIAB_ITEM.get().getDefaultInstance())

--- a/neoforge/src/main/java/org/mangorage/tiab/neoforge/core/Registration.java
+++ b/neoforge/src/main/java/org/mangorage/tiab/neoforge/core/Registration.java
@@ -46,7 +46,7 @@ public final class Registration {
             () -> EntityType.Builder.<TimeAcceleratorEntity>of(
                     (entityType, level) -> new TimeAcceleratorEntity(level),
                     MobCategory.MISC
-            ).build("accelerator"));
+            ).sized​(1.0f, 1.0f).build("accelerator"));
 
     public static final DeferredHolder<CreativeModeTab, CreativeModeTab> TIAB_CREATIVE_TAB = TABS.register("tiab", () -> CreativeModeTab.builder()
             .icon(() -> TIAB_ITEM.get().getDefaultInstance())


### PR DESCRIPTION
Level.getEntitiesOfClass(Class, AABB) seems to also return entities in the 2 blocks below the given AABB for some reason. Excluding these by additionally matching the BlockPos of all found entities with the targeted BlockPos fixes the issue.

Fixes #22 