### PR TITLE
Title: Block acceleration for mods listed in config ("API Access")

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ minecraft_version=1.20.1
 forge_version=47.1.43
 jei_version=15.2.0.23
 #Mod Info
-version=4.0.4
+version=4.0.5
 api_version=1.0.0

--- a/src/main/java/com/haoict/tiab/common/core/api/TimeInABottleAPI.java
+++ b/src/main/java/com/haoict/tiab/common/core/api/TimeInABottleAPI.java
@@ -10,6 +10,8 @@ import com.haoict.tiab.common.utils.Utils;
 import com.magorage.tiab.api.ITimeInABottleAPI;
 import com.magorage.tiab.api.TiabProvider;
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionResult;
@@ -192,6 +194,24 @@ public final class TimeInABottleAPI implements ITimeInABottleAPI {
 
     @Override
     public InteractionResult accelerateBlock(ITimeInABottleAPI API, ItemStack stack, Player player, Level level, BlockPos pos) {
+        // If the requesting mod has had API access revoked via config, block the action
+        if (TiabConfig.COMMON.MODS_API.get().contains(API_MOD_ID)) {
+            return InteractionResult.FAIL;
+        }
+
+        // Also prevent accelerating blocks that belong to a mod listed in the API access blocklist
+        if (level != null && pos != null) {
+            var blockState = level.getBlockState(pos);
+            var block = blockState.getBlock();
+            ResourceLocation rl = ForgeRegistries.BLOCKS.getKey(block);
+            if (rl != null) {
+                String namespace = rl.getNamespace();
+                if (TiabConfig.COMMON.MODS_API.get().contains(namespace)) {
+                    return InteractionResult.FAIL;
+                }
+            }
+        }
+
         var api = REGISTRY.getRegistered(ITimeInABottleItemAPI.class);
         if (api != null) {
             return api.accelerateBlock(API, stack, player, level, pos);

--- a/src/main/java/com/haoict/tiab/common/entities/TimeAcceleratorEntity.java
+++ b/src/main/java/com/haoict/tiab/common/entities/TimeAcceleratorEntity.java
@@ -20,6 +20,8 @@ import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.network.NetworkHooks;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.resources.ResourceLocation;
 
 public class TimeAcceleratorEntity extends Entity {
     private static final EntityDataAccessor<Integer> timeRate = SynchedEntityData.defineId(TimeAcceleratorEntity.class, EntityDataSerializers.INT);
@@ -55,6 +57,15 @@ public class TimeAcceleratorEntity extends Entity {
         }
 
         BlockState blockState = level.getBlockState(pos);
+        // If the block at this position belongs to a mod that is blocked in config, stop accelerating it
+        ResourceLocation rl = ForgeRegistries.BLOCKS.getKey(blockState.getBlock());
+        if (rl != null) {
+            String namespace = rl.getNamespace();
+            if (TiabConfig.COMMON.MODS_API.get().contains(namespace)) {
+                this.remove(RemovalReason.KILLED);
+                return;
+            }
+        }
         ServerLevel serverWorld = level.getServer().getLevel(level.dimension());
         BlockEntity targetTE = level.getBlockEntity(pos);
 

--- a/src/main/java/com/haoict/tiab/common/items/AbstractTiabItem.java
+++ b/src/main/java/com/haoict/tiab/common/items/AbstractTiabItem.java
@@ -4,10 +4,10 @@ import com.haoict.tiab.common.config.Constants;
 import com.haoict.tiab.common.config.TiabConfig;
 import com.haoict.tiab.common.entities.TimeAcceleratorEntity;
 import com.haoict.tiab.common.utils.PlaySound;
-import com.haoict.tiab.common.utils.SendMessage;
 import com.magorage.tiab.api.ITimeInABottleAPI;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
@@ -53,17 +53,35 @@ public abstract class AbstractTiabItem extends Item {
             return InteractionResult.FAIL;
         }
 
+        // Check if the block's owning mod is blocked from API access
+        ResourceLocation rl = ForgeRegistries.BLOCKS.getKey(blockState.getBlock());
+        if (rl != null) {
+            String namespace = rl.getNamespace();
+            if (TiabConfig.COMMON.MODS_API.get().contains(namespace)) {
+                return InteractionResult.FAIL;
+            }
+        }
+
         if (API.canUse()) {
             accelerateBlock(API, stack, player, level, pos);
         } else {
-            if (!API.callUseEvent(stack, player, level, pos) && player instanceof ServerPlayer serverPlayer)
-                SendMessage.sendStatusMessage(serverPlayer, "TIAB has had its API access revoked.");
-
+            // silently block when API usage is revoked
+            return InteractionResult.FAIL;
         }
         return InteractionResult.SUCCESS;
     }
 
     public InteractionResult accelerateBlock(ITimeInABottleAPI API, ItemStack stack, Player player, Level level, BlockPos pos) {
+        // Prevent acceleration if the block belongs to a blocked mod
+        var blockState = level.getBlockState(pos);
+        ResourceLocation rl = ForgeRegistries.BLOCKS.getKey(blockState.getBlock());
+        if (rl != null) {
+            String namespace = rl.getNamespace();
+            if (TiabConfig.COMMON.MODS_API.get().contains(namespace)) {
+                return InteractionResult.FAIL;
+            }
+        }
+
         int nextRate = 1;
         int energyRequired = API.getEnergyCost(nextRate);
         boolean isCreativeMode = player != null && player.isCreative();


### PR DESCRIPTION
Body: Summary: Prevent accelerating blocks when either the API consumer or the target block's mod (by registry namespace) is listed in the API Access config.

What changed: Added early checks in TimeInABottleAPI.accelerateBlock, AbstractTiabItem.useOn/accelerateBlock and TimeAcceleratorEntity.tick to refuse or remove accelerators for blocked namespaces. 